### PR TITLE
fix: removing unnecessary methods on migrations

### DIFF
--- a/src/database/migrations/20180910221504_init.js
+++ b/src/database/migrations/20180910221504_init.js
@@ -1,19 +1,11 @@
 export const up = knex =>
   knex.schema
     .createTable('roles', table => {
-      table
-        .increments('id')
-        .unique()
-        .notNullable()
-        .primary()
+      table.increments('id').primary()
       table.string('role').notNullable()
     })
     .createTable('users', table => {
-      table
-        .uuid('id')
-        .unique()
-        .primary()
-        .notNullable()
+      table.uuid('id').primary()
       table.string('name').notNullable()
       table
         .specificType('email', 'CITEXT')


### PR DESCRIPTION
Citando a documentação do Postgres na parte de primary keys (https://www.postgresql.org/docs/8.1/ddl-constraints.html): 


```
Technically, a primary key constraint is simply a combination of a unique constraint and a not-null constraint. 
So, the following two table definitions accept the same data:

CREATE TABLE products (
    product_no integer UNIQUE NOT NULL,
    name text,
    price numeric
);
CREATE TABLE products (
    product_no integer PRIMARY KEY,
    name text,
    price numeric
);
```

Assim sendo, não há necessidade dos métodos `.unique()` e `.notNullable()` junto ao método `.primary()`, pois se tornam redundantes.