### PR TITLE
feat(logger): add pino to log server.listen and our error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=10.14.0"
   },
   "scripts": {
-    "dev": "nodemon src/index.js --exec babel-node --inspect src/index.js",
+    "dev": "nodemon src/index.js --exec babel-node --inspect src/index.js | pino-pretty -c",
     "start": "node build/index.js",
     "build": "rm -rf build && mkdir build && babel src -s -d build",
     "pm2": "pm2 start build/index.js -i ${PM2_WORKERS-2} --max-memory-restart ${PM2_MAX_MEM-256M} --env production",
@@ -80,6 +80,7 @@
     "objection-guid": "^3.0.2",
     "objection-visibility": "^1.0.0",
     "pg": "^8.0.0",
+    "pino": "^6.5.1",
     "sqlite3": "^4.1.0",
     "uuid": "^7.0.3",
     "xhr2": "^0.2.0"
@@ -104,6 +105,7 @@
     "jest": "^25.3.0",
     "lint-staged": "10.1.2",
     "nodemon": "^2.0.2",
+    "pino-pretty": "^4.1.0",
     "prettier": "^2.0.4",
     "supertest": "^4.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import app from 'server'
 import process from 'process'
+import logger from 'logger'
 
 import { PORT } from 'config'
 
@@ -9,6 +10,6 @@ process.on('SIGINT', () => app.shutdown())
 
 process.on('SIGTERM', () => app.shutdown())
 
-app.listen(PORT, () => console.log(`Listening on port ${PORT}`))
+app.listen(PORT, () => logger.info(`Listening on port ${PORT}`))
 
 export default app

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,6 @@
+import pino from 'pino'
+
+export default pino({
+  enabled: true,
+  level: 'info'
+})

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,7 @@ import Cors from '@koa/cors'
 import koaBody from 'koa-body'
 import jwt from 'koa-jwt'
 import helmet from 'koa-helmet'
+import logger from 'logger'
 
 import routes from 'routes'
 import { getToken } from 'middlewares'
@@ -29,6 +30,7 @@ app.use(async (ctx, next) => {
   try {
     ctx.body = await next()
   } catch (err) {
+    logger.error(err)
     const errorObject = errorHandling(err)
     ctx.status = errorObject.statusCode
     ctx.body = errorObject


### PR DESCRIPTION
O objetivo desse PR é adicionar a biblioteca pino, pino-pettry e usa-la para logar o server.listen e nosso middleware de error handling.