### PR TITLE
refactor: remove linter in pre commit

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,7 +1,7 @@
 {
   "hooks": {
     "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-    "pre-commit": "echo 'Pre-commit checks...' && lint-staged && yarn prettier",
+    "pre-commit": "echo 'Pre-commit checks...' && lint-staged",
     "pre-push": "echo 'Pre-push checks...' && yarn test"
   }
 }

--- a/src/helpers/transporter-postgres.js
+++ b/src/helpers/transporter-postgres.js
@@ -45,9 +45,8 @@ export class PostgresTransport extends Transport {
 }
 
 export const createTransporterPostgres = () => {
-  const [user, passwordWithRemainingString, portWithRemaining] = DATABASE.split(
-    '//'
-  )[1].split(':')
+  const [user, passwordWithRemainingString, portWithRemaining] =
+    DATABASE.split('//')[1].split(':')
 
   const [port, database] = portWithRemaining.split('/')
 


### PR DESCRIPTION
O objetivo desse pr é fazer com que o linter não passe mais por todos os arquivos no commit. 

[TASK](https://naveteam.atlassian.net/browse/NAVE-15?atlOrigin=eyJpIjoiNzcwNTZlMTkyYTc5NDYwMDgzM2U2NWY0ZTkzMTYxNmIiLCJwIjoiaiJ9)