### PR TITLE
fix: change eslint and babel-eslint versions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": ["prettier/standard"],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "plugins": ["import", "prettier", "standard"],
   "rules": {
     "indent": ["error", 2, { "SwitchCase": 1 }],

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.0.0",
+    "@babel/eslint-parser": "^7.14.7",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-do-expressions": "^7.0.0",
@@ -98,7 +99,7 @@
     "chance": "^1.1.7",
     "commitlint": "^8.2.0",
     "cz-conventional-changelog": "^3.0.2",
-    "eslint": "^6.4.0",
+    "eslint": "^7.30.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.20.2",

--- a/src/helpers/transporter-postgres.js
+++ b/src/helpers/transporter-postgres.js
@@ -45,9 +45,8 @@ export class PostgresTransport extends Transport {
 }
 
 export const createTransporterPostgres = () => {
-  const [user, passwordWithRemainingString, portWithRemaining] = DATABASE.split(
-    '//'
-  )[1].split(':')
+  const [user, passwordWithRemainingString, portWithRemaining] =
+    DATABASE.split('//')[1].split(':')
 
   const [port, database] = portWithRemaining.split('/')
 


### PR DESCRIPTION
Foi feito o upgrade de `babel-eslint` para `@babel/eslint-parser`.
Ele causava erro nos testes e foi resolvido alterando para o pacote mais novo.

Erro:

![image](https://user-images.githubusercontent.com/42576333/125190509-f48bf100-e213-11eb-99cb-3d37d1d0b2b6.png)
