### PR TITLE
feat(modelpaths): add models path who turn unecessary model imports

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,6 +1,5 @@
 import { Model } from 'objection'
 
-import Role from './Role'
 import { baseModel, modelUuid } from './index'
 
 class User extends modelUuid(baseModel) {
@@ -10,7 +9,7 @@ class User extends modelUuid(baseModel) {
   static relationMappings = {
     role: {
       relation: Model.BelongsToOneRelation,
-      modelClass: Role,
+      modelClass: 'Role',
       join: {
         from: 'users.role_id',
         to: 'roles.id'

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -12,6 +12,10 @@ Model.knex(knex)
 
 export const modelUuid = guid()
 export class baseModel extends mixin(Model, [visibility, DBErrors]) {
+  static get modelPaths() {
+    return [__dirname]
+  }
+
   static query(...args) {
     return super.query(...args)
   }


### PR DESCRIPTION
Foi adicionado o `modelPaths` que torna desnecessário o import dos models para cada arquivo.
 Também não precisamos mais utlizar o `modelClass: () => 'Model'`, agora é possivel utilizar dessa maneira: `modelClass: 'Model'`.
[DOC](https://vincit.github.io/objection.js/api/model/static-properties.html#static-modelpaths)