### PR TITLE
fix: change default storage bucket

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ export const DATABASE_TEST =
   process.env.DATABASE_TEST ||
   'postgres://USER:PASSWORD@localhost:5432/DATABASE_TEST'
 export const NODE_ENV = process.env.NODE_ENV || 'development'
-export const BUCKET_TYPE = process.env.BUCKET_TYPE || 'firebase'
+export const BUCKET_TYPE = process.env.BUCKET_TYPE || 'aws'
 export const URL_FRONT = process.env.URL_FRONT || 'localhost'
 export const EXPIRE_TIME = process.env.EXPIRE_TIME || 1200
 export const LOGGER_NAME = process.env.LOGGER_NAME || 'boilerplate'


### PR DESCRIPTION
Neste PR alterei o valor padrão da config BUCKET_TYPE, visto que o maior uso do boilerplate é em ambientes da AWS