### PR TITLE
refactor(helpers): create pre-signed URLs

### DIFF
--- a/src/helpers/imgBucket/aws.js
+++ b/src/helpers/imgBucket/aws.js
@@ -35,7 +35,7 @@ export const uploadImage = async (filename, file) => {
       ACL: 'public-read',
     }
     const command = new PutObjectCommand(s3Params)
-    return signedUrl = await getSignedUrl(s3, command, {expiresIn: 120})
+    return getSignedUrl(s3, command, {expiresIn: 120})
 
   } catch (error) {
     throw new Error(error)


### PR DESCRIPTION
Neste PR modifiquei a função de uploadImage e getImage da aws para utilizar URLs pré assinadas que dão acesso as Imagens.